### PR TITLE
Added condition before assigning paramsForServer query

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -9,7 +9,17 @@ module.exports = function Client(appVersion) {
 
     const { params } = context;
     const { query } = paramsForServer({ currentAppVersion: appVersion });
-    params.query = Object.assign({}, query, params.query);
+
+    const fieldToAssign = Object.keys(query).shift();
+
+    if (params.query[fieldToAssign]) {
+      params.query[fieldToAssign] = Object
+        .assign({}, params.query[fieldToAssign], query[fieldToAssign]);
+    }
+
+    if (!params.query[fieldToAssign]) {
+      params.query = Object.assign({}, params.query, query);
+    }
 
     return Promise.resolve(context);
   };


### PR DESCRIPTION
This is to address the issue of overriding the $client in `params.query` on the `Client` hook.

This is the fix for the issue https://github.com/oizpans/feathers-version-checker/issues/5